### PR TITLE
fix #3 Service 타입 변경

### DIFF
--- a/infra/backend/backend-service.yaml
+++ b/infra/backend/backend-service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   name: backend-service
 spec:
-  clusterIP: None
   selector:
     app: infra-backend
   ports:


### PR DESCRIPTION
* Headless -> ClusterIP 로 변경
Headless service로 작성할 경우 내부 관리하는 Pod를 직접 가리키기 때문에, deployment 재생성 시 주소가 달라지게 된다
따라서 ClusterIP로 바꿔서 로드밸런싱 역할을 할 수 있도록 한다